### PR TITLE
Export the update function directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-module.exports.update = update
+module.exports = update
 
 var simplesets = require('simplesets');
 
@@ -56,7 +56,7 @@ function _pushAll(obj, keys, values) {
   if (deepest[_last(keys)]) {
     for (var index in values) {
       if (values[index] in deepest) {
-        
+
       }
     }
   } else {

--- a/test/addtoset.js
+++ b/test/addtoset.js
@@ -32,7 +32,7 @@ describe('$addToSet operator', function () {
       'baz': ['stomp'],
       'extra': ['read all about it'],
     };
-    var result = mupdate.update(local, update);
+    var result = mupdate(local, update);
 
     assert.deepEqual(result, expected);
     assert.deepEqual(local, result);

--- a/test/push.js
+++ b/test/push.js
@@ -30,7 +30,7 @@ describe('$push operator', function () {
       },
       'list': ['foo', 'bar', 'taz'],
     };
-    var result = mupdate.update(local, update);
+    var result = mupdate(local, update);
   
     assert.deepEqual(result, expected);
     assert.deepEqual(local, result);

--- a/test/readme.js
+++ b/test/readme.js
@@ -39,11 +39,11 @@ describe('Readme example', function () {
           },
       },
     };
-    var result = mupdate.update(local, update);
+    var result = mupdate(local, update);
 
     assert.deepEqual(result, expected);
     assert.deepEqual(local, result);
-    
+
     return done();
   });
 });

--- a/test/set.js
+++ b/test/set.js
@@ -33,11 +33,11 @@ describe('$set operator', function () {
       'list': ['foo', 'bar'],
       'list2': ['fooer', 'barrer'],
     };
-    var result = mupdate.update(local, update);
-  
+    var result = mupdate(local, update);
+
     assert.deepEqual(result, expected);
     assert.deepEqual(local, result);
-    
+
     return done();
   });
 });

--- a/test/unset.js
+++ b/test/unset.js
@@ -29,11 +29,11 @@ describe('$unset operator', function () {
       'deeper': {},
       'list': ['foo', 'bar'],
     };
-    var result = mupdate.update(local, update);
-  
+    var result = mupdate(local, update);
+
     assert.deepEqual(result, expected);
     assert.deepEqual(local, result);
-    
+
     return done();
   });
 });


### PR DESCRIPTION
This is sometimes referred to as the "substack pattern" (see http://www.futurealoof.com/posts/coffee-perspective.html)

Instead of calling `mupdate.update(obj, change)`, you would simply call `mupdate(obj, change)`